### PR TITLE
buildroot: add Raspberry Pi hardware compatibility and SD card sizing guidance

### DIFF
--- a/buildroot/README.md
+++ b/buildroot/README.md
@@ -86,7 +86,7 @@ Image layout sizing:
 That means the generated image is about 384 MB plus partition-table/alignment overhead.
 Practical guidance:
 
-- Absolute minimum card size: **512 MB**
+- Absolute minimum card size: **1 GB**
 - Recommended minimum for reliability/availability: **1 GB**
 
 ### Docker resource settings (recommended)

--- a/buildroot/README.md
+++ b/buildroot/README.md
@@ -75,8 +75,8 @@ Uses Docker to avoid host dependencies. Build artifacts stored in a Docker volum
 ## Hardware compatibility and minimum SD card size
 
 - Target hardware: Raspberry Pi Zero W.
-- Raspberry Pi Zero 2 W can boot this image in many setups, but it is not the primary
-  validated target in this repository; verify in your environment before production use.
+- Raspberry Pi Zero 2 W may run this image but is not officially validated; test in your
+  environment before production use.
 
 Image layout sizing:
 

--- a/buildroot/README.md
+++ b/buildroot/README.md
@@ -72,6 +72,23 @@ Uses Docker to avoid host dependencies. Build artifacts stored in a Docker volum
 ./scripts/docker_build.sh --clear-docker-cache
 ```
 
+## Hardware compatibility and minimum SD card size
+
+- Target hardware: Raspberry Pi Zero W.
+- Raspberry Pi Zero 2 W can boot this image in many setups, but it is not the primary
+  validated target in this repository; verify in your environment before production use.
+
+Image layout sizing:
+
+- Boot partition: `128M` (`board/raspberrypi0w/genimage.cfg`).
+- Root filesystem image: `256M` (`configs/virtualchime_rpi0w_defconfig`).
+
+That means the generated image is about 384 MB plus partition-table/alignment overhead.
+Practical guidance:
+
+- Absolute minimum card size: **512 MB**
+- Recommended minimum for reliability/availability: **1 GB**
+
 ### Docker resource settings (recommended)
 
 If your Mac is mostly idle during builds, Docker is likely CPU/RAM-limited.


### PR DESCRIPTION
### Motivation

- Clarify target hardware and compatibility expectations for the buildroot image to reduce surprises when flashing and booting devices.
- Provide explicit image layout sizing so users understand how partition sizes map to generated image size.
- Offer practical guidance on minimum and recommended SD card sizes to improve reliability for deployments.

### Description

- Add a new "Hardware compatibility and minimum SD card size" section to `buildroot/README.md` documenting the target hardware as `Raspberry Pi Zero W` and noting that `Raspberry Pi Zero 2 W` may work but is not the primary validated target. 
- Document image layout sizing, including `Boot partition: 128M` (from `board/raspberrypi0w/genimage.cfg`) and `Root filesystem image: 256M` (from `configs/virtualchime_rpi0w_defconfig`).
- State the approximate generated image size (~384 MB) and provide `Absolute minimum card size: 512 MB` and `Recommended minimum for reliability/availability: 1 GB` guidance.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a18e1bff5c832189774b969eeb8ef7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added hardware compatibility and minimum SD card guidance: notes on target device support, image layout and approximate resulting image size, and practical minimum/recommended card sizes for reliable use.
  * Included Docker Desktop resource recommendations for local builds and a pointer to existing fast-iteration workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->