### PR TITLE
webui: add Biome linting and Tailwind setup (TW-12)

### DIFF
--- a/webui/README.md
+++ b/webui/README.md
@@ -2,6 +2,23 @@
 
 This directory contains the Svelte + Vite frontend for `chime-webd`.
 
+## Tooling
+
+This project uses **Bun as the default package manager/runtime** for local frontend tasks.
+
+Install dependencies:
+
+```bash
+cd webui
+bun install
+```
+
+Run linting (Biome):
+
+```bash
+bun run lint
+```
+
 ## Local Development
 
 From the repository root:
@@ -27,3 +44,7 @@ Vite proxies `/api/*` to `https://127.0.0.1:8443` (TLS verification disabled for
 This writes static assets to `webui/dist/`.
 
 When `CHIME_WEBD_UI_DIST_DIR` points at that directory, `chime-webd` serves the built UI instead of the embedded fallback HTML.
+
+## Styling
+
+Tailwind CSS is configured via the Vite plugin and imported in `src/app.css`.

--- a/webui/biome.json
+++ b/webui/biome.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "files": {
+    "ignore": ["dist", "node_modules", "src/**/*.svelte"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space"
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/webui/package.json
+++ b/webui/package.json
@@ -6,11 +6,16 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "biome check .",
+    "format": "biome check --write ."
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "@tailwindcss/vite": "^4.1.12",
     "svelte": "^5.0.0",
+    "tailwindcss": "^4.1.12",
     "typescript": "^5.6.0",
     "vite": "^5.4.0"
   }

--- a/webui/src/app.css
+++ b/webui/src/app.css
@@ -1,3 +1,5 @@
+@import "tailwindcss";
+
 :root {
   --bg: #f2f4f7;
   --card: #ffffff;

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -1,8 +1,9 @@
 import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  plugins: [svelte()],
+  plugins: [svelte(), tailwindcss()],
   server: {
     proxy: {
       "/api": {


### PR DESCRIPTION
### Motivation
- Add a linter/formatter to the web UI and document the preferred local tooling to improve code quality and developer ergonomics. 
- Integrate Tailwind CSS so the frontend can adopt utility-first styles via Vite.

### Description
- Add `webui/biome.json` to enable Biome formatting and recommended lint rules while ignoring `dist`, `node_modules`, and Svelte sources. 
- Update `webui/package.json` to add `lint` (`biome check .`) and `format` (`biome check --write .`) scripts and declare Biome and Tailwind-related dev dependencies. 
- Wire Tailwind into Vite by adding `@tailwindcss/vite` to `webui/vite.config.ts` plugins. 
- Import Tailwind in `webui/src/app.css` by prepending `@import "tailwindcss";`. 
- Update `webui/README.md` to recommend Bun as the default package manager/runtime and document install and lint commands.

### Testing
- Ran `bun --version` which succeeded and returned a usable Bun runtime. 
- Attempted `npm install` which failed with a 403 from the npm registry in this environment. 
- Attempted `bun install` which failed with 403 errors resolving packages from the registry, preventing dependency installation. 
- Attempted `bun run lint` and `bun run build` but both failed because required binaries/packages (`biome`, `@tailwindcss/vite`) were unavailable until dependencies can be installed; failures are due to registry access restrictions in the execution environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a305a94c8c8321b5d5ea1aa99924ce)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation to include development tooling and styling configuration guidance
  * Configured automated code linting and formatting capabilities
  * Integrated Tailwind CSS framework for enhanced styling support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->