### PR TITLE
Add changed-file lint/format checks to CI pipeline

### DIFF
--- a/.github/workflows/chime-ci.yml
+++ b/.github/workflows/chime-ci.yml
@@ -5,18 +5,28 @@ on:
     paths:
       - "chime/**"
       - "common/**"
+      - "webui/**"
       - "scripts/chime_ci.sh"
+      - "scripts/lint_format_ci.sh"
       - ".github/workflows/chime-ci.yml"
       - ".clang-format"
       - ".clang-tidy"
+      - "webui/biome.json"
+      - "webui/package.json"
+      - "webui/package-lock.json"
   pull_request:
     paths:
       - "chime/**"
       - "common/**"
+      - "webui/**"
       - "scripts/chime_ci.sh"
+      - "scripts/lint_format_ci.sh"
       - ".github/workflows/chime-ci.yml"
       - ".clang-format"
       - ".clang-tidy"
+      - "webui/biome.json"
+      - "webui/package.json"
+      - "webui/package-lock.json"
   workflow_dispatch:
 
 jobs:
@@ -40,6 +50,11 @@ jobs:
         with:
           cmake-version: "4.0.0"
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
       - name: Install deps
         run: |
           sudo apt-get update
@@ -48,6 +63,10 @@ jobs:
             libmosquitto-dev \
             libssl-dev \
             clang-format clang-tidy
+
+      - name: Install webui deps
+        working-directory: webui
+        run: npm ci
 
       - name: Determine CI file scope
         run: |
@@ -76,6 +95,10 @@ jobs:
             echo "CHIME_CI_SCOPE=all" >> "$GITHUB_ENV"
             echo "CHIME_CI_BASE_REF=" >> "$GITHUB_ENV"
           fi
+
+      - name: Run repository lint/format checks
+        run: |
+          bash ./scripts/lint_format_ci.sh
 
       - name: Run chime CI checks
         env:

--- a/chime/README.md
+++ b/chime/README.md
@@ -17,6 +17,12 @@ Useful options:
 - `./scripts/chime_ci.sh --fix-format` to apply `clang-format` to the checked files.
 - `CHIME_CI_SCOPE=changed CHIME_CI_BASE_REF=origin/main ./scripts/chime_ci.sh` to lint/format only files changed from a base ref.
 
+For repository-wide formatting/lint checks (C/C++ + webui Biome), run:
+
+```bash
+./scripts/lint_format_ci.sh
+```
+
 ## Runtime Behavior
 
 1. Loads config from `/etc/chime.conf` (or `$CHIME_CONFIG`).

--- a/scripts/lint_format_ci.sh
+++ b/scripts/lint_format_ci.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+SCOPE="${CHIME_CI_SCOPE:-all}"
+BASE_REF="${CHIME_CI_BASE_REF:-}"
+FIX_FORMAT=0
+SKIP_CXX=0
+SKIP_WEBUI=0
+
+log() {
+  echo "[lint-format-ci] $*"
+}
+
+error() {
+  echo "[lint-format-ci] ERROR: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Runs formatting and linting checks used by CI.
+
+Options:
+  --scope <all|changed>     File scope (default: all)
+  --base-ref <git-ref>      Base ref for --scope changed (or CHIME_CI_BASE_REF)
+  --fix-format              Apply formatters in place instead of check-only
+  --skip-cxx                Skip C/C++ clang-format checks
+  --skip-webui              Skip webui biome checks
+  -h, --help                Show this help text
+USAGE
+}
+
+parse_args() {
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --scope)
+        [ $# -ge 2 ] || error "--scope requires a value"
+        SCOPE="$2"
+        shift 2
+        ;;
+      --base-ref)
+        [ $# -ge 2 ] || error "--base-ref requires a value"
+        BASE_REF="$2"
+        shift 2
+        ;;
+      --fix-format)
+        FIX_FORMAT=1
+        shift
+        ;;
+      --skip-cxx)
+        SKIP_CXX=1
+        shift
+        ;;
+      --skip-webui)
+        SKIP_WEBUI=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        error "Unknown argument: $1"
+        ;;
+    esac
+  done
+
+  case "$SCOPE" in
+    all|changed) ;;
+    *) error "Invalid scope '$SCOPE' (expected all or changed)" ;;
+  esac
+
+  if [ "$SCOPE" = "changed" ] && [ -z "$BASE_REF" ]; then
+    error "changed scope requires --base-ref or CHIME_CI_BASE_REF"
+  fi
+}
+
+require_tool() {
+  local tool="$1"
+  command -v "$tool" >/dev/null 2>&1 || error "Required tool not found: $tool"
+}
+
+is_cxx_file() {
+  local path="$1"
+  case "$path" in
+    chime/*|common/*) ;;
+    *) return 1 ;;
+  esac
+
+  case "$path" in
+    *.c|*.cc|*.cpp|*.h|*.hpp) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_webui_file() {
+  local path="$1"
+  case "$path" in
+    webui/*) ;;
+    *) return 1 ;;
+  esac
+
+  case "$path" in
+    webui/node_modules/*|webui/dist/*) return 1 ;;
+  esac
+
+  case "$path" in
+    *.js|*.jsx|*.mjs|*.cjs|*.ts|*.tsx|*.json|*.jsonc|*.css|*.svelte) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+collect_candidates() {
+  if [ "$SCOPE" = "all" ]; then
+    git ls-files -z -- chime common webui
+    return 0
+  fi
+
+  git rev-parse --verify "${BASE_REF}^{commit}" >/dev/null 2>&1 || \
+    error "Base ref does not resolve to a commit: $BASE_REF"
+
+  local merge_base
+  merge_base="$(git merge-base "$BASE_REF" HEAD)"
+  [ -n "$merge_base" ] || error "Failed to find merge-base for $BASE_REF and HEAD"
+
+  log "Using merge-base $merge_base (base ref: $BASE_REF)"
+  git diff --name-only --diff-filter=ACMR -z "$merge_base" HEAD -- chime common webui
+  return 0
+}
+
+collect_files() {
+  local mode="$1"
+  local file
+
+  while IFS= read -r -d '' file; do
+    [ -f "$PROJECT_DIR/$file" ] || continue
+
+    case "$mode" in
+      cxx)
+        is_cxx_file "$file" && printf '%s\0' "$file"
+        ;;
+      webui)
+        is_webui_file "$file" && printf '%s\0' "$file"
+        ;;
+      *)
+        error "Unknown collect mode: $mode"
+        ;;
+    esac
+  done < <(collect_candidates)
+
+  return 0
+}
+
+load_file_array() {
+  local mode="$1"
+  local -n out_ref="$2"
+  local tmp_file
+  tmp_file="$(mktemp)"
+
+  collect_files "$mode" > "$tmp_file"
+
+  while IFS= read -r -d '' file; do
+    out_ref+=("$file")
+  done < "$tmp_file"
+
+  rm -f "$tmp_file"
+}
+
+run_clang_format() {
+  [ "$SKIP_CXX" = "1" ] && {
+    log "Skipping C/C++ checks"
+    return
+  }
+
+  require_tool clang-format
+
+  local files=()
+  load_file_array cxx files
+
+  if [ "${#files[@]}" -eq 0 ]; then
+    log "No C/C++ files selected for clang-format"
+    return
+  fi
+
+  clang-format --version
+  log "clang-format files: ${#files[@]}"
+
+  if [ "$FIX_FORMAT" = "1" ]; then
+    clang-format -i "${files[@]}"
+    log "Applied clang-format"
+  else
+    clang-format -n -Werror "${files[@]}"
+    log "clang-format check passed"
+  fi
+}
+
+run_biome() {
+  [ "$SKIP_WEBUI" = "1" ] && {
+    log "Skipping webui checks"
+    return
+  }
+
+  require_tool npm
+
+  local files=()
+  load_file_array webui files
+
+  if [ "${#files[@]}" -eq 0 ]; then
+    log "No webui files selected for biome"
+    return
+  fi
+
+  log "biome files: ${#files[@]}"
+
+  pushd "$PROJECT_DIR/webui" >/dev/null
+  if [ "$FIX_FORMAT" = "1" ]; then
+    npx --no-install @biomejs/biome check --write "${files[@]/#webui\//}"
+    log "Applied biome formatting/lint fixes"
+  else
+    npx --no-install @biomejs/biome check "${files[@]/#webui\//}"
+    log "biome check passed"
+  fi
+  popd >/dev/null
+}
+
+main() {
+  parse_args "$@"
+
+  git -C "$PROJECT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1 || \
+    error "Must run inside the repository"
+  cd "$PROJECT_DIR"
+
+  run_clang_format
+  run_biome
+
+  log "All requested checks passed"
+}
+
+main "$@"

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
 import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [svelte(), tailwindcss()],


### PR DESCRIPTION
### Motivation
- Enforce repository formatting and linting in CI (C/C++ + webui) so commits/PRs cannot skip format checks without relying on local hooks. 
- Run checks only on the changed files for push/PR (`all` vs `changed` scope) to avoid failing CI on legacy baseline issues. 
- Make web UI linting runnable in CI by installing Node dependencies and invoking the project's Biome config.

### Description
- Add `scripts/lint_format_ci.sh`, a helper that supports `--scope all|changed`, uses merge-base detection, collects changed files under `chime/`, `common/`, and `webui/`, and runs `clang-format` for C/C++ and Biome checks for web files. 
- Update `.github/workflows/chime-ci.yml` to include `webui/**` in watched paths, set up Node.js, run `npm ci` in `webui`, and execute `scripts/lint_format_ci.sh` before the existing `scripts/chime_ci.sh` job. 
- Document the new command in `chime/README.md` and reorder imports in `webui/vite.config.ts` to satisfy Biome import-sorting rules.

### Testing
- Performed a shell syntax check with `bash -n scripts/lint_format_ci.sh scripts/chime_ci.sh` which succeeded. 
- Ran `./scripts/lint_format_ci.sh --skip-cxx --skip-webui` which completed successfully. 
- Ran `./scripts/lint_format_ci.sh --skip-cxx` to exercise Biome checks and it passed after fixing the `vite.config.ts` import ordering. 
- Ran the full `./scripts/lint_format_ci.sh` and `--scope changed --base-ref HEAD~1` which correctly invoked `clang-format` and reported expected baseline C/C++ formatting violations (these are pre-existing and intentional to keep CI scoped to changed files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6903045588321b63670f8d12e910b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide formatting and lint checks documentation.

* **Chores**
  * Enhanced CI workflow with Node.js environment setup.
  * Added automated lint and format validation checks to ensure code quality standards across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->